### PR TITLE
Initialize project structure with env files

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Default development environment variables
+DATABASE_URL=sqlite:///./local.db
+SECRET_KEY=change_me

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# Virtual environment
+venv/
+.env
+
+# Node modules
+frontend/node_modules/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Stock Management System – Real-World Vision
 
 ## 🧭 Mission
-
 This is not a typical SaaS app — it's a **real-world stock tracking system** built to solve the practical pains of managing stock across departments, users, and roles in a company.
 
 The goal is to:
@@ -39,17 +38,16 @@ The goal is to:
 
 ## 🔐 Access Control Examples
 
-| Role             | View              | Can Do                                                                 |
-|------------------|-------------------|------------------------------------------------------------------------|
-| `admin`          | Everything         | Manage stock, users, departments, audits                              |
-| `warehouse`      | Warehouse dept     | Reassign stock, mark issues, restock                                  |
-| `tech_support`   | Only own issued items | Return items, view equipment assigned                                |
-| `sales`          | Possibly none      | Can request stock but not manage it directly                         |
+| Role           | View                  | Can Do                                             |
+|----------------|-----------------------|----------------------------------------------------|
+| `admin`        | Everything            | Manage stock, users, departments, audits           |
+| `warehouse`    | Warehouse department  | Reassign stock, mark issues, restock               |
+| `tech_support` | Only own issued items | Return items, view equipment assigned              |
+| `sales`        | Possibly none         | Can request stock but not manage it directly       |
 
 ---
 
 ## 🧠 Smart Behaviors
-
 - When **stock runs low**, par levels trigger a restock warning.
 - **Broken items** are marked and excluded from usable counts.
 - **Aging assets** can be tracked by acquisition date.
@@ -58,7 +56,6 @@ The goal is to:
 ---
 
 ## 💻 System Stack
-
 - **Backend**: FastAPI + SQLAlchemy + Alembic
 - **Frontend**: Next.js + React + shadcn/ui (via V0.dev)
 - **Auth**: JWT + role-based access control
@@ -68,7 +65,6 @@ The goal is to:
 ---
 
 ## 🧪 Examples of Good Codex Tasks
-
 - ✅ "Generate a React dashboard for a warehouse user that lets them reassign stock between users in the same department."
 - ✅ "Create a FastAPI endpoint to issue an item to a user and log the assignment with timestamp and issuer."
 - ✅ "Add a QR code scanning input field to the restock form to auto-fill the item."
@@ -76,24 +72,36 @@ The goal is to:
 ---
 
 ## ❌ Avoid
-
 - ❌ Generic CRUD without context (e.g., “Create product” with no link to department)
 - ❌ Single-tenant assumptions — this system must support multiple companies
 - ❌ Unstructured UI suggestions — all flows should reflect real operational intent
 
 ---
 
-## 🛠️ Setup
+## 🛠️ Local Setup
 
-```bash
-# Backend
-python3 -m venv venv
-source venv/bin/activate
-pip install -r requirements.txt
-alembic upgrade head
-uvicorn app.main:app --reload
+1. **Clone and create a virtual environment**
+   ```bash
+   python3 -m venv venv
+   source venv/bin/activate
+   pip install -r backend/requirements.txt
+   ```
+2. **Environment variables**
+   - Copy `.env.example` to `.env` and adjust values if needed.
+   - `DATABASE_URL` defaults to SQLite (`sqlite:///./local.db`). Use a PostgreSQL URL for production.
+3. **Initialize the database with sample data**
+   ```bash
+   python backend/sample_data.py
+   ```
+4. **Run the backend**
+   ```bash
+   uvicorn app.main:app --reload --app-dir backend
+   ```
+5. **Run the frontend**
+   ```bash
+   cd frontend
+   npm install
+   npm run dev
+   ```
 
-# Frontend
-cd frontend
-npm install
-npm run dev
+This project uses SQLite for convenience during development but is designed to work with PostgreSQL in production.

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,0 +1,9 @@
+import os
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./local.db")
+
+engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False} if DATABASE_URL.startswith("sqlite") else {})
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,8 @@
+from fastapi import FastAPI
+
+app = FastAPI(title="Stock Management System")
+
+
+@app.get("/")
+def read_root():
+    return {"message": "Stock Management API"}

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,0 +1,26 @@
+from sqlalchemy import Column, Integer, String, ForeignKey
+from sqlalchemy.orm import relationship
+
+from .database import Base
+
+class Department(Base):
+    __tablename__ = "departments"
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, unique=True, index=True)
+
+
+class Role(Base):
+    __tablename__ = "roles"
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, unique=True, index=True)
+
+
+class User(Base):
+    __tablename__ = "users"
+    id = Column(Integer, primary_key=True, index=True)
+    username = Column(String, unique=True, index=True)
+    role_id = Column(Integer, ForeignKey("roles.id"))
+    department_id = Column(Integer, ForeignKey("departments.id"))
+
+    role = relationship("Role")
+    department = relationship("Department")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,6 @@
+fastapi
+uvicorn
+sqlalchemy
+psycopg2-binary
+alembic
+python-dotenv

--- a/backend/sample_data.py
+++ b/backend/sample_data.py
@@ -1,0 +1,30 @@
+from app.database import Base, engine, SessionLocal
+from app.models import Department, Role, User
+
+
+def init_db():
+    Base.metadata.create_all(bind=engine)
+    db = SessionLocal()
+    # Create sample departments
+    warehouse = Department(name="Warehouse")
+    it = Department(name="IT")
+    db.add_all([warehouse, it])
+
+    # Create sample roles
+    admin_role = Role(name="admin")
+    warehouse_role = Role(name="warehouse")
+    tech_support_role = Role(name="technical_support")
+    db.add_all([admin_role, warehouse_role, tech_support_role])
+
+    # Sample users
+    admin = User(username="admin", role=admin_role, department=it)
+    worker = User(username="worker", role=warehouse_role, department=warehouse)
+    tech = User(username="tech", role=tech_support_role, department=it)
+    db.add_all([admin, worker, tech])
+
+    db.commit()
+    db.close()
+
+
+if __name__ == "__main__":
+    init_db()

--- a/env/setup.sh
+++ b/env/setup.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+python3 -m venv venv
+source venv/bin/activate
+pip install -r backend/requirements.txt

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,5 @@
+# Frontend
+
+This folder contains the Next.js frontend for the Stock Management System.
+
+Run `npm install` and `npm run dev` to start the development server.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "stock-management-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "latest",
+    "react-dom": "latest"
+  }
+}


### PR DESCRIPTION
## Summary
- add backend FastAPI skeleton
- add frontend placeholder with Next.js package.json
- add env setup script and .env.example
- provide sample data for roles and departments
- rewrite README with setup instructions

## Testing
- `python -m py_compile backend/app/*.py backend/sample_data.py`

------
https://chatgpt.com/codex/tasks/task_e_6849652b9e208331bbe0f237479b6b4a