### PR TITLE
Add audit log querying and stock reporting features

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The goal is to:
   - Who did it
   - When
   - Why (optional reason/comment)
+- Admins can query audit logs by item, user, or department.
 
 ---
 
@@ -52,6 +53,7 @@ The goal is to:
 - **Broken items** are marked and excluded from usable counts.
 - **Aging assets** can be tracked by acquisition date.
 - Staff can be assigned specific equipment (e.g., laptops, phones) with full responsibility trail.
+- Reports can be filtered by par levels, age, and faulty status.
 
 ---
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -50,6 +50,9 @@ class StockItem(Base):
     department_id = Column(Integer, ForeignKey("departments.id"))
     company_id = Column(Integer, ForeignKey("companies.id"), index=True)
     is_faulty = Column(Boolean, default=False)
+    par_level = Column(Integer, nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    is_deleted = Column(Boolean, default=False)
 
     department = relationship("Department")
     company = relationship("Company")

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -6,6 +6,7 @@ class StockAddRequest(BaseModel):
     name: str
     quantity: int
     department_id: int
+    par_level: Optional[int] = None
 
 class StockAssignRequest(BaseModel):
     stock_item_id: int
@@ -28,6 +29,8 @@ class StockItemResponse(BaseModel):
     quantity: int
     department_id: int
     is_faulty: bool
+    par_level: Optional[int] = None
+    created_at: datetime
 
     class Config:
         orm_mode = True

--- a/backend/sample_data.py
+++ b/backend/sample_data.py
@@ -52,12 +52,14 @@ def init_db():
         quantity=5,
         department_id=warehouse.id,
         company_id=company.id,
+        par_level=2,
     )
     phone = StockItem(
         name="Phone",
         quantity=3,
         department_id=it.id,
         company_id=company.id,
+        par_level=2,
     )
     db.add_all([laptop, phone])
 


### PR DESCRIPTION
## Summary
- store par level, creation time and deletion state for stock items
- log creation versus addition of stock
- add API to delete stock
- extend stock listing with par level/aging/status filters
- admin API to query audit logs
- document how audit logs and filters work

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r backend/requirements.txt`
- `python backend/sample_data.py`

------
https://chatgpt.com/codex/tasks/task_e_68496b351fd88331a39f38a141fea6a4