### PR TITLE
Add department/user filters to stock listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ The goal is to:
 - **Aging assets** can be tracked by acquisition date.
 - Staff can be assigned specific equipment (e.g., laptops, phones) with full responsibility trail.
 - Reports can be filtered by par levels, age, and faulty status.
+- The stock listing API also allows filtering results by department or by the user an item is assigned to.
 
 ---
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -311,7 +311,7 @@ def view_stock(
     db: Session = Depends(get_db),
 ):
     if user_id is not None:
-        assignments = (
+        assign_q = (
             db.query(Assignment)
             .join(StockItem)
             .filter(
@@ -320,8 +320,10 @@ def view_stock(
                 Assignment.company_id == current_user.company_id,
                 StockItem.is_deleted == False,
             )
-            .all()
         )
+        if department_id is not None:
+            assign_q = assign_q.filter(StockItem.department_id == department_id)
+        assignments = assign_q.all()
         return [a.stock_item for a in assignments]
     q = db.query(StockItem).filter(
         StockItem.company_id == current_user.company_id,


### PR DESCRIPTION
## Summary
- filter stock listing by department when filtering by user
- document stock listing filters in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68496c5b222883319f9823e30c798f08