### PR TITLE
Add reason field to stock history

### DIFF
--- a/backend/alembic/versions/1b6814358839_add_reason_to_stock_history.py
+++ b/backend/alembic/versions/1b6814358839_add_reason_to_stock_history.py
@@ -1,0 +1,23 @@
+"""add reason to stock_history
+
+Revision ID: 1b6814358839
+Revises: 5497bbca3cb0
+Create Date: 2025-06-11 11:23:06.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '1b6814358839'
+down_revision = '5497bbca3cb0'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column('stock_history', sa.Column('reason', sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('stock_history', 'reason')

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -87,6 +87,7 @@ def add_stock(
                 user_id=current_user.id,
                 company_id=current_user.company_id,
                 action="add",
+                reason=payload.reason,
             )
         )
     else:
@@ -105,6 +106,7 @@ def add_stock(
                 user_id=current_user.id,
                 company_id=current_user.company_id,
                 action="create",
+                reason=payload.reason,
             )
         )
     db.commit()
@@ -150,6 +152,7 @@ def assign_stock(
             user_id=current_user.id,
             company_id=current_user.company_id,
             action="assign",
+            reason=payload.reason,
         )
     )
     db.commit()
@@ -182,6 +185,7 @@ def return_stock(
             user_id=current_user.id,
             company_id=current_user.company_id,
             action="return",
+            reason=payload.reason,
         )
     )
     db.commit()
@@ -212,6 +216,7 @@ def mark_faulty(
             user_id=current_user.id,
             company_id=current_user.company_id,
             action="faulty",
+            reason=payload.reason,
         )
     )
     db.commit()
@@ -264,6 +269,7 @@ def transfer_stock(
             user_id=current_user.id,
             company_id=current_user.company_id,
             action="transfer",
+            reason=payload.reason,
         )
     )
     db.commit()
@@ -273,6 +279,7 @@ def transfer_stock(
 @app.post("/stock/delete/{item_id}")
 def delete_stock(
     item_id: int,
+    reason: str | None = None,
     current_user=Depends(auth.require_role("warehouse")),
     db: Session = Depends(get_db),
 ):
@@ -294,6 +301,7 @@ def delete_stock(
             user_id=current_user.id,
             company_id=current_user.company_id,
             action="delete",
+            reason=reason,
         )
     )
     db.commit()

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -64,6 +64,7 @@ class StockHistory(Base):
     stock_item_id = Column(Integer, ForeignKey("stock_items.id"))
     user_id = Column(Integer, ForeignKey("users.id"))
     action = Column(String)
+    reason = Column(String, nullable=True)
     timestamp = Column(DateTime, default=datetime.utcnow)
     company_id = Column(Integer, ForeignKey("companies.id"), index=True)
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -7,21 +7,26 @@ class StockAddRequest(BaseModel):
     quantity: int
     department_id: int
     par_level: Optional[int] = None
+    reason: Optional[str] = None
 
 class StockAssignRequest(BaseModel):
     stock_item_id: int
     assignee_user_id: int
+    reason: Optional[str] = None
 
 class StockReturnRequest(BaseModel):
     assignment_id: int
+    reason: Optional[str] = None
 
 class StockFaultyRequest(BaseModel):
     stock_item_id: int
+    reason: Optional[str] = None
 
 class StockTransferRequest(BaseModel):
     stock_item_id: int
     to_department_id: int
     quantity: int
+    reason: Optional[str] = None
 
 class StockItemResponse(BaseModel):
     id: int
@@ -40,6 +45,7 @@ class StockHistoryResponse(BaseModel):
     stock_item_id: int
     user_id: Optional[int]
     action: str
+    reason: Optional[str] = None
     timestamp: datetime
 
     class Config:


### PR DESCRIPTION
## Summary
- support reason/comment on stock history
- expose optional reason field in request/response models
- wire reason field through stock operations
- add Alembic migration for the new column

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68496c81fa0c833182dd5d99c16889de