### PR TITLE
Implement par-level warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ The goal is to:
 
 ## 🧠 Smart Behaviors
 - When **stock runs low**, par levels trigger a restock warning.
+- Use the `/stock/warnings` endpoint to list items below their par levels.
+- Par levels can be updated via `PATCH /stock/par-level/{item_id}`.
 - **Broken items** are marked and excluded from usable counts.
 - **Aging assets** can be tracked by acquisition date.
 - Staff can be assigned specific equipment (e.g., laptops, phones) with full responsibility trail.

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -57,6 +57,13 @@ class StockItem(Base):
     department = relationship("Department")
     company = relationship("Company")
 
+    @property
+    def below_par(self) -> bool:
+        """Return True if item quantity is below its par level."""
+        if self.par_level is None:
+            return False
+        return self.quantity < self.par_level
+
 
 class StockHistory(Base):
     __tablename__ = "stock_history"

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -23,6 +23,9 @@ class StockTransferRequest(BaseModel):
     to_department_id: int
     quantity: int
 
+class ParLevelUpdateRequest(BaseModel):
+    par_level: Optional[int]
+
 class StockItemResponse(BaseModel):
     id: int
     name: str
@@ -31,6 +34,7 @@ class StockItemResponse(BaseModel):
     is_faulty: bool
     par_level: Optional[int] = None
     created_at: datetime
+    below_par: bool
 
     class Config:
         orm_mode = True


### PR DESCRIPTION
## Summary
- expose par level info in StockItemResponse
- add endpoint to patch par level for an item
- expose `/stock/warnings` to list items under their par level
- note usage in README

## Testing
- `python -m py_compile backend/app/*.py backend/*.py`
- `python -m pip install -r backend/requirements.txt`
- `python backend/sample_data.py`

------
https://chatgpt.com/codex/tasks/task_e_68496c873e688331ba88e7383655c61b